### PR TITLE
changed labels for panes manager and Made the greek pop-over disappear when click away

### DIFF
--- a/components/AddPaneModal.js
+++ b/components/AddPaneModal.js
@@ -1,25 +1,23 @@
 /**
-  * @author      Manny Colon
-  * @description This component displays a modal when the user clicks the add
-  * resources button on the scripture pane module.
-******************************************************************************/
-const api = window.ModuleApi;
-const React = api.React;
-const RB = api.ReactBootstrap;
-const {Modal, Button, FormControl} = RB;
+ * @description This component displays a modal when the user clicks the add
+ * resources button on the scripture pane module.
+ */
+import React from 'react';
+import {Modal, Button, FormControl} from 'react-bootstrap';
 
-class AddPaneModal extends React.Component {
+
+export default class AddPaneModal extends React.Component {
   render() {
     let { staticPaneSettings, selectSourceLanguage, addPane, show, onHide } = this.props;
     /**
      * @description The code below generates a list of resource names and saves
      * it in option elements for the user to select from a dropdown list.
-    *******************************************************************************/
+     */
     let panes = [];
     for (let key in staticPaneSettings) {
       panes.push(
         <option key={key} value={staticPaneSettings[key].sourceName.toString()}>
-          {staticPaneSettings[key].sourceName}
+          {staticPaneSettings[key].heading.heading}
         </option>
       );
     }
@@ -51,5 +49,3 @@ class AddPaneModal extends React.Component {
     );
   }
 }
-
-module.exports = AddPaneModal;

--- a/components/VerseDisplay.js
+++ b/components/VerseDisplay.js
@@ -23,28 +23,31 @@ class VerseDisplay extends React.Component {
     let {
       showPopover
     } = actions;
-    return text.map((word) => {
-      var PopoverTitle = <span>
-                           {word.word + " | "}
-                           <a href={'http://studybible.info/mac/' + word.speech}
-                              target="_blank">
-                             <b>
-                              {word.speech}
-                             </b>
-                           </a>
-                         </span>
-      return (<span
-                key={i++}
-                style={{cursor: 'pointer'}}
-                onClick={function(e){
-                  var x = e.target.getBoundingClientRect().left;
-                  var y = e.target.getBoundingClientRect().bottom;
-                  var positionCoord = [x, y];
-                  showPopover(PopoverTitle, word.brief, positionCoord);
-                }}>
-                  {word.word + " "}
-                </span>
-              );
+    return text.map(word => {
+      const PopoverTitle = (
+        <span>
+          {word.word + " | "}
+          <a href={'http://studybible.info/mac/' + word.speech}
+            target="_blank">
+            <b>
+            {word.speech}
+            </b>
+          </a>
+        </span>
+      );
+      return (
+        <span
+          key={i++}
+          style={{cursor: 'pointer'}}
+          onClick={
+            (e) => {
+              let positionCoord = e.target;
+              showPopover(PopoverTitle, word.brief, positionCoord);
+            }
+          }>
+            {word.word + " "}
+          </span>
+      );
     });
   }
 


### PR DESCRIPTION
#### This pull request addresses:
- Change Labels for Scripture Pane Content Manager #895
https://github.com/unfoldingWord-dev/translationCore/issues/895

- Made the greek pop-over disappear when clicking away #1055
https://github.com/unfoldingWord-dev/translationCore/pull/1055

#### How to test this pull request:
- Try clicking a greek word and a pop over should open just like before but now it will close when clicking away.

- Try adding a new language to the scripture pane and the drop down menu should display the following options:
```
 Instead of "Gateway Language" say "English (ULB)"
 Instead of "Original Language" say "Greek (UGNT)"
 Instead of "Target Language" say [whatever the name of the language is] (e.g. "Ilokano")
 Instead of "UDB" say "English (UDB)"
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/32)
<!-- Reviewable:end -->
