### PR TITLE
issue 1067, remove pipe after greek text

### DIFF
--- a/components/VerseDisplay.js
+++ b/components/VerseDisplay.js
@@ -23,13 +23,7 @@ class VerseDisplay extends React.Component {
     return text.map(word => {
       const PopoverTitle = (
         <span>
-          {word.word + " | "}
-          <a href={'http://studybible.info/mac/' + word.speech}
-            target="_blank">
-            <b>
-            {word.speech}
-            </b>
-          </a>
+          {word.word}
         </span>
       );
       return (


### PR DESCRIPTION
#### This pull request addresses:

Remove pipe after greek text, also removed defunct a tag for "part of speech".



#### How to test this pull request:

Confirm that greek text is displayed without a "|" after it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/34)
<!-- Reviewable:end -->
