### PR TITLE
Fix target language direction

### DIFF
--- a/components/Pane.js
+++ b/components/Pane.js
@@ -12,10 +12,10 @@ class Pane extends React.Component {
       removePane,
       heading,
       id,
+      dir,
       isGatewayLanguage,
       actions
     } = this.props;
-    let dir = this.props.projectDetailsReducer.manifest.target_language.direction
     let {
       showPopover
     } = actions;

--- a/components/Pane.js
+++ b/components/Pane.js
@@ -11,11 +11,11 @@ class Pane extends React.Component {
       greek,
       removePane,
       heading,
-      dir,
       id,
       isGatewayLanguage,
       actions
     } = this.props;
+    let dir = this.props.projectDetailsReducer.manifest.target_language.direction
     let {
       showPopover
     } = actions;

--- a/components/View.js
+++ b/components/View.js
@@ -44,7 +44,7 @@ class View extends React.Component {
       if (pane[key].sourceName === "gatewayLanguage") {
         isGatewayLanguage = true;
       }
-      let dir = pane[key].dir || "ltr";
+      let dir = pane[key].dir || this.props.projectDetailsReducer.manifest.target_language.direction;
       if (scripturePane.length <= 3) {
         scripturePane.push(
           <Pane


### PR DESCRIPTION
#### This pull request addresses:

Addresses https://github.com/unfoldingWord-dev/translationCore/issues/1065



#### How to test this pull request:

Load a project that is read from right to left instead of left to right. It should now properly display in the scripture pane when you select target language.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/36)
<!-- Reviewable:end -->
