### PR TITLE
Pane Modal now shows correct direction on target language

### DIFF
--- a/components/ExpandedPane.js
+++ b/components/ExpandedPane.js
@@ -23,6 +23,10 @@ class ExpandedPane extends Component {
     let greek = paneInfo.sourceName === "originalLanguage" ? true : false;
     let isGatewayLanguage = paneInfo.sourceName === "gatewayLanguage" ? true : false;
     let currentChapter = bibles[paneInfo.sourceName][chapterNumber];
+    let dir = "ltr";
+    if(paneInfo.sourceName === "targetLanguage"){
+      dir = this.props.projectDetailsReducer.manifest.target_language.direction
+    }
     for (var verseNum in currentChapter) {
       let versePaneStyle = {};
       if (verseNum == contextIdReducer.contextId.reference.verse) {
@@ -40,6 +44,7 @@ class ExpandedPane extends Component {
         <Col key={verseNum} md={12} sm={12} xs={12} lg={12} style={versePaneStyle}>
           <VerseDisplay
             {...this.props}
+            dir={dir}
             chapter={chapterNumber}
             verse={verseNum}
             input={bibles[paneInfo.sourceName]}

--- a/components/VerseDisplay.js
+++ b/components/VerseDisplay.js
@@ -86,14 +86,14 @@ class VerseDisplay extends React.Component {
           </span>
         );
       return (
-        <div>
+        <div style={{direction: this.props.dir}}>
           <b>{chapter + ":" + verse + " "}</b>
           {newContent}
         </div>
       )
     }
     return (
-      <div>
+      <div style={{direction: this.props.dir}}>
         <b>{chapter + ":" + verse + " "}</b>
         {content}
       </div>


### PR DESCRIPTION
#### This pull request addresses:
https://github.com/unfoldingWord-dev/translationCore/issues/1101



#### How to test this pull request:

Click the button on the top right of the scripture pane. You should see the target language in the correct direction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/37)
<!-- Reviewable:end -->
