### PR TITLE
Show proper language text in chapter view

### DIFF
--- a/components/chapterView/VerseRow.js
+++ b/components/chapterView/VerseRow.js
@@ -20,10 +20,10 @@ class VerseRow extends React.Component {
     let isCurrent = verseNumber == verse;
     if (isCurrent) colStyle.borderLeft = '3px solid var(--accent-color)';
     if (currentPaneSettings.length > 0) {
-      verseCells = currentPaneSettings.map((resource, index) => {
-        let bibleId = bibleIdFromSourceName(resource.sourceName);
+      verseCells = currentPaneSettings.map((bibleId, index) => {
+        let manifest = bibles[bibleId].manifest;
         let verseText = bibles[bibleId][chapter][verseNumber];
-        let dir = resource.dir;
+        let dir = manifest.dir;
         if (bibleId === 'targetLanguage') {
           dir = this.props.projectDetailsReducer.manifest.target_language.direction
         }
@@ -31,7 +31,7 @@ class VerseRow extends React.Component {
         return (
           <Col key={index} md={4} sm={4} xs={4} lg={4} style={colStyle}>
             <Verse {...this.props}
-              sourceName={resource.sourceName}
+              sourceName={bibleId}
               isCurrent={isCurrent}
               verseText={verseText}
               chapter={chapter}


### PR DESCRIPTION
#### This pull request addresses:

This fixes the Chapter-view popup to show the proper language instead of the target language.


#### How to test this pull request:

- Open any project and tool.
- Expand the Scripture Pane and ensure that it shows all the languages properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/58)
<!-- Reviewable:end -->
