### PR TITLE
Truncated the language header name on the scripture pane

### DIFF
--- a/components/Pane.js
+++ b/components/Pane.js
@@ -27,8 +27,8 @@ class Pane extends React.Component {
       <div style={index > 0 ? style.otherPane : style.firstPane}>
         <div style={style.verseTitle}>
           <div style={{display: 'flex', flexDirection: 'column'}}>
-            <span style={style.pane.title}>
-              {headingText}
+            <span style={style.pane.title} className={headingText.length > 15 ? "hint--bottom hint--medium" : null} aria-label={headingText}>
+              {headingText.length > 15 ? headingText.slice(0, 15) + '...' : headingText}
             </span>
             <span style={style.pane.subtitle}>
               {description || ''}


### PR DESCRIPTION
### This pull request addresses:
- Truncated the language header name on the scripture pane and added hover over action to display full header name


### How to test this pull request:
- Open a project with a long language name. 
##### Note: 
If you cant find one just edit the manifest file 
e.g. 
```
"target_language":{"id":"fr","direction":"ltr","name":"français frança frança frança"}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/59)
<!-- Reviewable:end -->
