### PR TITLE
Support for new UGNT v0.2 and lexicon

### DIFF
--- a/Container.js
+++ b/Container.js
@@ -74,6 +74,7 @@ class ScripturePane extends React.Component {
   }
 
   render() {
+console.log(this.props);
     return (
       <MuiThemeProvider>
         <View

--- a/Container.js
+++ b/Container.js
@@ -74,7 +74,6 @@ class ScripturePane extends React.Component {
   }
 
   render() {
-console.log(this.props);
     return (
       <MuiThemeProvider>
         <View

--- a/components/Pane.js
+++ b/components/Pane.js
@@ -12,8 +12,9 @@ class Pane extends React.Component {
     let { bibles } = this.props.resourcesReducer;
 
     let { direction, language_name, resource_id, description } = bibles[bibleId]["manifest"];
-    // look up verseText
-    let verseText = bibles[bibleId][reference.chapter][reference.verse];
+    // look up verseText, replace with placeholder text if not found;
+    const placeholderText = 'This Bible version does not include text for this reference.';
+    let verseText = bibles[bibleId][reference.chapter] ? bibles[bibleId][reference.chapter][reference.verse] : placeholderText;
     let headingText = bibleId !== "targetLanguage" ? language_name + " (" + bibleId.toUpperCase() + ")" : language_name;
     let contentStyle;
 

--- a/components/Verse.js
+++ b/components/Verse.js
@@ -2,20 +2,36 @@ import React from 'react';
 import XRegExp from 'xregexp';
 // helpers
 import * as highlightHelpers from '../helpers/highlightHelpers';
+import * as lexiconHelpers from '../helpers/lexiconHelpers';
+// components
+import WordDetails from './WordDetails';
 
 class Verse extends React.Component {
 
-  verseArray(verseText = []) {
-    let { showPopover } = this.props.actions;
-    let verseSpan = verseText.map( (word, index) => {
-      const PopoverTitle = <span>{word.word}</span>;
-      let click = (e) => {
-        let positionCoord = e.target;
-        showPopover(PopoverTitle, word.brief, positionCoord);
-      }
+  componentWillMount() {
+    const {verseText} = this.props;
+    if (verseText.constructor == Array) {
+      this.props.verseText.forEach((word) => {
+        const {strongs} = word
+        const entryId = lexiconHelpers.lexiconEntryIdFromStrongs(strongs);
+        const lexiconId = lexiconHelpers.lexiconIdFromStrongs(strongs);
+        this.props.actions.loadLexiconEntry(lexiconId, entryId);
+      });
+    }
+  }
 
+  onClick(e, word) {
+    let positionCoord = e.target;
+    const PopoverTitle = <strong style={{fontSize: '1.2em'}}>{word.word}</strong>;
+    let { showPopover } = this.props.actions;
+    const wordDetails = <WordDetails {...this.props} word={word} />;
+    showPopover(PopoverTitle, wordDetails, positionCoord);
+  }
+
+  verseArray(verseText = []) {
+    let verseSpan = verseText.map( (word, index) => {
       return (
-        <span style={{cursor: 'pointer'}} onClick={click} key={index}>
+        <span style={{cursor: 'pointer'}} onClick={(e)=>this.onClick(e, word)} key={index}>
           {word.word + " "}
         </span>
       );

--- a/components/WordDetails.js
+++ b/components/WordDetails.js
@@ -1,0 +1,28 @@
+import React from 'react';
+// helpers
+import * as lexiconHelpers from '../helpers/lexiconHelpers';
+
+class WordDetails extends React.Component {
+
+  render() {
+    let {word, lemma, morph, strongs} = this.props.word;
+
+    let lexicon;
+    const {lexicons} = this.props.resourcesReducer;
+    const entryId = lexiconHelpers.lexiconEntryIdFromStrongs(strongs);
+    const lexiconId = lexiconHelpers.lexiconIdFromStrongs(strongs);
+    if (lexicons[lexiconId] && lexicons[lexiconId][entryId]) {
+      lexicon = lexicons[lexiconId][entryId].long;
+    }
+    return (
+      <div style={{margin: '-10px 10px -20px', maxWidth: '400px'}}>
+        <span><strong>Lemma:</strong> {lemma}</span><br/>
+        <span><strong>Morphology:</strong> {morph}</span><br/>
+        <span><strong>Strongs:</strong> {strongs}</span><br/>
+        <span><strong>Lexicon:</strong> {lexicon}</span><br/>
+      </div>
+    );
+  }
+}
+
+export default WordDetails;

--- a/helpers/lexiconHelpers.js
+++ b/helpers/lexiconHelpers.js
@@ -1,0 +1,18 @@
+/**
+ * @description - Get the lexiconId from the strongs number
+ * @param {String} strongs - the strongs number to get the entryId from
+ * @return {String} - the id of the lexicon
+ */
+export const lexiconIdFromStrongs = (strongs) => {
+  const lexiconId = (strongs.replace(/\d+/,'') === 'G') ? 'ugl': 'uhl';
+  return lexiconId;
+}
+/**
+ * @description - Get the lexicon entryId from the strongs number
+ * @param {String} strongs - the strongs number to get the entryId from
+ * @return {Int} - the number of the entry
+ */
+export const lexiconEntryIdFromStrongs = (strongs) => {
+  const entryId = parseInt(strongs.replace(/\w/,'').slice(0,-1));
+  return entryId;
+}


### PR DESCRIPTION
#### This pull request addresses:

Replaces Greek UGNT with v0.2 and updated lexicon.

#### How to test this pull request:

- Check out the same branch on Core
- Delete your ~/translationCore/resources folder so that launching the app populates the resources folder
- Load a Titus project, and tW, click on the Greek words in the scripture pane to get the Lexicon entries.
- Load a non-Titus project and tW, verify that the app doesn't crash but displays placeholder text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/63)
<!-- Reviewable:end -->
