### PR TITLE
Fixed Text Direction On Expanded Scripture Pane

### DIFF
--- a/components/chapterView/VerseRow.js
+++ b/components/chapterView/VerseRow.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {Col, Row} from 'react-bootstrap';
 import Verse from '../Verse';
 import {bibleIdFromSourceName} from '../../helpers/bibleHelpers';
+const PLACE_HOLDER_TEXT = 'This Bible version does not include text for this reference.';
 
 class VerseRow extends React.Component {
 
@@ -22,7 +23,7 @@ class VerseRow extends React.Component {
     if (currentPaneSettings.length > 0) {
       verseCells = currentPaneSettings.map((bibleId, index) => {
         let manifest = bibles[bibleId].manifest;
-        let verseText = bibles[bibleId][chapter][verseNumber];
+        let verseText = bibles[bibleId][chapter] ? bibles[bibleId][chapter][verseNumber] : PLACE_HOLDER_TEXT;
         let dir = manifest.dir;
         if (bibleId === 'targetLanguage') {
           dir = this.props.projectDetailsReducer.manifest.target_language.direction

--- a/components/chapterView/VerseRow.js
+++ b/components/chapterView/VerseRow.js
@@ -24,9 +24,9 @@ class VerseRow extends React.Component {
       verseCells = currentPaneSettings.map((bibleId, index) => {
         let manifest = bibles[bibleId].manifest;
         let verseText = bibles[bibleId][chapter] ? bibles[bibleId][chapter][verseNumber] : PLACE_HOLDER_TEXT;
-        let dir = manifest.dir;
+        let direction = manifest.direction;
         if (bibleId === 'targetLanguage') {
-          dir = this.props.projectDetailsReducer.manifest.target_language.direction
+          direction = this.props.projectDetailsReducer.manifest.target_language.direction
         }
 
         return (
@@ -37,7 +37,7 @@ class VerseRow extends React.Component {
               verseText={verseText}
               chapter={chapter}
               verse={verseNumber}
-              dir={dir}
+              direction={direction}
             />
           </Col>
         )


### PR DESCRIPTION
#### This pull request addresses:
This PR:
Adds place holder text to the expanded scripture pane just like the one on the regular scripture pane, to catch missing books.
Adds correct direction for the bible in the expanded scripture pane

#### How to test this pull request:
Open the project 
[ar_eph_text_ulb.zip](https://github.com/translationCoreApps/ScripturePane/files/1323289/ar_eph_text_ulb.zip)
open the expanded scripture pane and ensure each bible has the right language direction

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/64)
<!-- Reviewable:end -->
