### PR TITLE
Filtering Footnotes From Text

### DIFF
--- a/components/Verse.js
+++ b/components/Verse.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import XRegExp from 'xregexp';
+import usfmjs from 'usfm-js';
 // helpers
 import * as highlightHelpers from '../helpers/highlightHelpers';
 import * as lexiconHelpers from '../helpers/lexiconHelpers';
@@ -71,11 +72,11 @@ class Verse extends React.Component {
     afterText = aroundQuote[aroundQuoteIndex][1] + afterText;  // prepend the current quote's preceding char
     verseSpan.push(
       <span key={1}>
-        <span>{beforeText}</span>
+        <span>{usfmjs.removeMarker(beforeText)}</span>
         <span style={{backgroundColor: "var(--highlight-color)"}}>
           {quote}
         </span>
-        <span>{afterText}</span>
+        <span>{usfmjs.removeMarker(afterText)}</span>
       </span>
     );
     return verseSpan;


### PR DESCRIPTION
#### This pull request addresses:
This PR utilizes the new filtering function in the usfm module to remove extra, unneeded tags.

#### How to test this pull request:
Checkout branch ```enhancement/jay/filter-footnotes/1941```
on Scripture Pane, and Verse Check (this is assuming the usfm latetest module with the filtering function has already been merged with develop)
and open an eph book on tN and find the check for 1:1 and ensure there are no footnotes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/65)
<!-- Reviewable:end -->
