### PR TITLE
Updated UGNT reference to BHP

### DIFF
--- a/helpers/bibleHelpers.js
+++ b/helpers/bibleHelpers.js
@@ -6,7 +6,7 @@ export const bibleIdFromSourceName = (sourceName) => {
       bibleId = 'ulb';
       break;
     case 'originalLanguage':
-      bibleId = 'ugnt';
+      bibleId = 'bhp';
       break;
     case 'UDB':
       bibleId = 'udb';
@@ -16,4 +16,4 @@ export const bibleIdFromSourceName = (sourceName) => {
       break;
   }
   return bibleId;
-}
+};


### PR DESCRIPTION
#### This pull request addresses:
- Updated `UGNT` reference to `BHP`
 
#### How to test this pull request:
- Delete the resources folder from the `translationCore` folder in the user directory.
- Then open a tool and you should not be able to load UGNT in the scripture pane
- This PR should be tested together with:
https://github.com/unfoldingWord-dev/translationCore/pull/2856
https://github.com/translationCoreApps/tC_Resources/pull/7
https://github.com/translationCoreApps/word-alignment-tool/pull/7
https://github.com/translationCoreApps/ScripturePane/pull/66
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/66)
<!-- Reviewable:end -->
