### PR TITLE
Added USFM Footnote Filtering To Missing Use Case

### DIFF
--- a/components/Verse.js
+++ b/components/Verse.js
@@ -91,7 +91,7 @@ class Verse extends React.Component {
       if (quote && verseText && isCurrent && bibleId === 'ulb' && !quote.includes("...") && isQuoteInVerse) {
         verseSpan = this.highlightQuoteInVerse(verseText, quote, occurrence);
       } else {
-        verseSpan = <span>{verseText}</span>;
+        verseSpan = <span>{usfmjs.removeMarker(verseText)}</span>;
       }
     } else {
       verseSpan = this.verseArray(verseText);


### PR DESCRIPTION
#### This pull request addresses:
This PR adds footnote filtering to a missing render condition.


#### How to test this pull request:
Test project ```2 Peter tW angel/angels check```
Test project ```Php tW amen/truly```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/67)
<!-- Reviewable:end -->
