### PR TITLE
Feature - #1279 - Adds titles to expanded scripture pane

### DIFF
--- a/__tests__/AddSomeTests.test.js
+++ b/__tests__/AddSomeTests.test.js
@@ -1,4 +1,0 @@
-
-test('We have tests', () => {
-    expect(false).toBeTruthy();
-});

--- a/__tests__/ChapterViewModal.test.js
+++ b/__tests__/ChapterViewModal.test.js
@@ -1,0 +1,31 @@
+/* eslint-env jest */
+
+import React from 'react';
+import ChapterViewModal from '../src/components/ChapterViewModal';
+import {shallow} from 'enzyme';
+import {Modal} from 'react-bootstrap';
+
+// Tests for ChapterViewModal React Component
+describe('Test ChapterViewModal component',()=>{
+  test('Tests that the modal\'s title is displayed', () => {
+    const props = {
+      onHide: jest.fn(),
+      projectDetailsReducer: {
+        manifest: {
+          project: {
+            name: 'My Book'
+          }
+        }
+      }
+    };
+    const expectedTitle = props['projectDetailsReducer']['manifest']['project']['name'];
+    const enzymeWrapper = shallow(<ChapterViewModal {...props} />);
+    validateModalTitle(enzymeWrapper, expectedTitle);
+  });
+});
+
+function validateModalTitle(enzymeWrapper, expectedTitle) {
+  const titleHeader = enzymeWrapper.find(Modal.Title).render().find('h4');
+  expect(titleHeader.length).toEqual(1);
+  expect(titleHeader.html()).toContain(expectedTitle);
+}

--- a/package.json
+++ b/package.json
@@ -29,13 +29,23 @@
     "babel-preset-env": "^1.6.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
-    "eslint": "^4.7.2",
+    "enzyme": "^2.9.1",
+    "eslint": "^4.10.0",
     "eslint-plugin-react": "^7.4.0",
     "jest": "^21.1.0",
-    "react-test-renderer": "^15.6.1"
+    "react": "^15.6.2",
+    "react-addons-test-utils": "^15.4.2",
+    "react-bootstrap": "^0.30.10",
+    "react-dnd": "^2.5.4",
+    "react-dnd-html5-backend": "^2.5.4",
+    "react-dom": "^15.4.2",
+    "react-redux": "^5.0.6",
+    "react-remarkable": "^1.1.3",
+    "react-test-renderer": "^15.6.2",
+    "usfm-js": "^1.0.0-beta.15",
+    "xregexp": "^3.2.0"
   },
   "dependencies": {
-    "react": "^15.6.1",
     "usfm-parser": "^0.1.6"
   }
 }

--- a/src/components/ChapterViewModal.js
+++ b/src/components/ChapterViewModal.js
@@ -12,12 +12,13 @@ import ChapterView from './chapterView/ChapterView';
 class ChapterViewModal extends React.Component {
 
   render() {
-    let { onHide, currentPaneSettings, contextIdReducer, showModal, show, bibles } = this.props;
-
+    let { onHide, currentPaneSettings, contextIdReducer, showModal, show, bibles, projectDetailsReducer } = this.props;
+    const title = projectDetailsReducer.manifest.project.name;
     return (
       <Modal show={show} onHide={onHide} bsSize="lg" aria-labelledby="contained-modal-title-sm">
         <Modal.Header style={{ backgroundColor: "var(--accent-color-dark)" }}>
-          <Modal.Title id="contained-modal-title-sm">
+          <Modal.Title id="contained-modal-title-sm" style={style.modalTitle}>
+              {title}
               <Glyphicon
                   onClick={onHide}
                   glyph={"remove"}

--- a/src/css/Style.js
+++ b/src/css/Style.js
@@ -74,6 +74,10 @@ var style = {
     display: 'flex',
     justifyContent: 'space-between',
     margin: '5px 10px 5px 15px'
+  },
+  modalTitle:{
+    textAlign: "center",
+    color: "var(--reverse-color)"
   }
 };
 


### PR DESCRIPTION
#### This pull request addresses:

Addresses Issue https://github.com/unfoldingWord-dev/translationCore/issues/1279 for the expanded scripture pane's title


#### How to test this pull request:

Go to tW tool for a project and expand the scripture pane at the top. It should show the name of the Bible book in the title.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/74)
<!-- Reviewable:end -->
