### PR TITLE
Bugfix #3486/wA Tool crashes on punctuation in greek.

### DIFF
--- a/src/components/Verse.js
+++ b/src/components/Verse.js
@@ -12,12 +12,16 @@ class Verse extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.verseText && this.props.verseText !== nextProps.verseText) {
-      if (nextProps.verseText.constructor == Array) {
+      if (nextProps.verseText.constructor === Array) {
         nextProps.verseText.forEach((word) => {
-          const { strongs } = word;
-          const entryId = lexiconHelpers.lexiconEntryIdFromStrongs(strongs);
-          const lexiconId = lexiconHelpers.lexiconIdFromStrongs(strongs);
-          nextProps.actions.loadLexiconEntry(lexiconId, entryId);
+          if (typeof word !== 'string') { // skip punctuation
+            const {strongs} = word;
+            if (strongs) {
+              const entryId = lexiconHelpers.lexiconEntryIdFromStrongs(strongs);
+              const lexiconId = lexiconHelpers.lexiconIdFromStrongs(strongs);
+              nextProps.actions.loadLexiconEntry(lexiconId, entryId);
+            }
+          }
         });
       }
     }


### PR DESCRIPTION
#### This pull request addresses:

Issue: unfoldingWord-dev/translationCore#3486

Verse.js - added skipping of punctuation in greek when loading lexicon.


#### How to test this pull request:

Import Hebrew usfm posted here: https://github.com/unfoldingWord-dev/translationCore/issues/3486

Step through verses 1 to 7 of chapter 1.  Changes should be quick.  Also BHP and ULB panes should track the verse change.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/79)
<!-- Reviewable:end -->
