### PR TITLE
Bugfix #3543/Fix issue that Greek punctuation renders as undefined.

### DIFF
--- a/src/components/Verse.js
+++ b/src/components/Verse.js
@@ -14,7 +14,7 @@ class Verse extends React.Component {
     if (nextProps.verseText && this.props.verseText !== nextProps.verseText) {
       if (nextProps.verseText.constructor === Array) {
         nextProps.verseText.forEach((word) => {
-          if (typeof word !== 'string') { // skip punctuation
+          if (isWord(word)) { 
             const {strongs} = word;
             if (strongs) {
               const entryId = lexiconHelpers.lexiconEntryIdFromStrongs(strongs);
@@ -37,11 +37,13 @@ class Verse extends React.Component {
 
   verseArray(verseText = []) {
     let verseSpan = verseText.map( (word, index) => {
-      return (
-        <span style={{cursor: 'pointer'}} onClick={(e)=>this.onClick(e, word)} key={index}>
-          {word.word + " "}
-        </span>
-      );
+      if (isWord(word)) {
+        return (
+          <span style={{cursor: 'pointer'}} onClick={(e)=>this.onClick(e, word)} key={index}>
+            {word.word + " "}
+          </span>
+        );
+      }
     });
 
     return verseSpan;
@@ -121,6 +123,10 @@ class Verse extends React.Component {
     );
   }
 }
+
+const isWord = (word => {
+  return typeof word !== 'string'; // TODO: will be changed for USFM3 with new verse objects
+});
 
 export default Verse;
 export {PLACE_HOLDER_TEXT};


### PR DESCRIPTION
#### This pull request addresses:

issue: https://github.com/unfoldingWord-dev/translationCore/issues/3543
issue: https://github.com/unfoldingWord-dev/translationCore/issues/3486

Fix issue that tries to render greek punctuation as undefined word


#### How to test this pull request:

Select Matthew project.  In wa tool select  ch. 2:26.  Should not see undefined at beginning of greek.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/80)
<!-- Reviewable:end -->
