### PR TITLE
Feature #3724/Extend USFM Cleaning

### DIFF
--- a/__tests__/Verse.test.js
+++ b/__tests__/Verse.test.js
@@ -52,14 +52,14 @@ describe('Test Verse component',()=>{
 
   test('Test that USFM is stripped out', () => {
     const props = {
-      verseText: 'Also, we are writing these things to you so that our joy will be complete. \\f + \\ft Some older versions read, \\fqa And we are writing these things to you so that your joy will be complete \\fqa* . \\f*\n\n\\s5\n\\p\n',
+      verseText: 'Also, we are writing these things to you so that our joy will be complete. \\f + \\ft Some older versions read, \\fqa And we are writing these things to you so that your joy will be complete \\fqa* . \\f*\n\n\\s5\n\\p\n\\q1\n',
       chapter: '1',
       verse: '1',
       contextIdReducer: {
         contextId: {}
       }
     };
-    const expectedText = '1:1 Also, we are writing these things to you so that our joy will be complete. \n\n\n\n';
+    const expectedText = '1:1 Also, we are writing these things to you so that our joy will be complete. \n\n\n\n\n';
     const enzymeWrapper = mount(<Verse {...props} />);
     validateVerse(enzymeWrapper, expectedText);
   });

--- a/__tests__/Verse.test.js
+++ b/__tests__/Verse.test.js
@@ -50,6 +50,20 @@ describe('Test Verse component',()=>{
     validateVerse(enzymeWrapper, expectedText);
   });
 
+  test('Test that USFM is stripped out', () => {
+    const props = {
+      verseText: 'Also, we are writing these things to you so that our joy will be complete. \\f + \\ft Some older versions read, \\fqa And we are writing these things to you so that your joy will be complete \\fqa* . \\f*\n\n\\s5\n\\p\n',
+      chapter: '1',
+      verse: '1',
+      contextIdReducer: {
+        contextId: {}
+      }
+    };
+    const expectedText = '1:1 Also, we are writing these things to you so that our joy will be complete. \n\n\n\n';
+    const enzymeWrapper = mount(<Verse {...props} />);
+    validateVerse(enzymeWrapper, expectedText);
+  });
+
   test('Test when verse is verseObject that the verse is displayed', () => {
     const props = {
       verseText: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -8316,9 +8316,9 @@
       "dev": true
     },
     "usfm-js": {
-      "version": "1.0.0-beta.17.2",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-1.0.0-beta.17.2.tgz",
-      "integrity": "sha512-3/83BtRdgWAGJoGqTTp622jzJuy7oJAUehSdwbs0LEJq9wddW+sdL2syQ/SozStZkXxj49E1KBzVZH5yzJYO8A==",
+      "version": "1.0.0-beta.23",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-1.0.0-beta.23.tgz",
+      "integrity": "sha512-T65Ahj3bUHSU9h4nh7Iw4HK/EbSWdWpfzpWwWujjUixqFhnvLPIMFveh3oaJ4zKyPzjY1iZhhHlLVpA8DFyBWg==",
       "requires": {
         "babel-runtime": "6.26.0",
         "rimraf": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prop-types": "15.6.0",
     "react": "16.2.0",
     "react-dom": "16.2.0",
-    "usfm-js": "1.0.0-beta.17.2",
+    "usfm-js": "1.0.0-beta.23",
     "xregexp": "3.2.0"
   }
 }

--- a/src/components/Verse.js
+++ b/src/components/Verse.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import XRegExp from 'xregexp';
-import usfmjs from 'usfm-js';
+import {removeMarker} from '../helpers/UsfmHelpers';
+
 // helpers
 import * as highlightHelpers from '../helpers/highlightHelpers';
 import * as lexiconHelpers from '../helpers/lexiconHelpers';
@@ -91,11 +92,11 @@ class Verse extends React.Component {
     afterText = aroundQuote[aroundQuoteIndex][1] + afterText;  // prepend the current quote's preceding char
     verseSpan.push(
       <span key={1}>
-        <span>{usfmjs.removeMarker(beforeText)}</span>
+        <span>{removeMarker(beforeText)}</span>
         <span style={{backgroundColor: "var(--highlight-color)"}}>
           {quote}
         </span>
-        <span>{usfmjs.removeMarker(afterText)}</span>
+        <span>{removeMarker(afterText)}</span>
       </span>
     );
     return verseSpan;
@@ -115,7 +116,7 @@ class Verse extends React.Component {
       if (quote && verseText && isCurrent && bibleId === 'ulb' && !quote.includes("...") && isQuoteInVerse) {
         verseSpan = this.highlightQuoteInVerse(verseText, quote, occurrence);
       } else {
-        verseSpan = <span>{usfmjs.removeMarker(verseText)}</span>;
+        verseSpan = <span>{removeMarker(verseText)}</span>;
       }
     } else {
       verseSpan = this.verseArray(verseText);

--- a/src/helpers/UsfmHelpers.js
+++ b/src/helpers/UsfmHelpers.js
@@ -1,0 +1,11 @@
+import usfmjs from 'usfm-js';
+/* Method to filter usfm markers from a string
+ * @param {string} verseText - The string to remove markers from
+ * @return {string}
+ */
+
+export const removeMarker = (verseText) => {
+  const cleaned = usfmjs.removeMarker(verseText, ['f', 'q(\\d)?', 's(\\d)?', 'p(\\d)?']); // remove these markers, 'f' is predefined
+                                                    // the rest are regex (these will be prefixed with '\\\\')
+  return cleaned;
+};


### PR DESCRIPTION
#### This pull request addresses:

Update usfm-js that supports passing in regex to remove arbitrary USFM markers.
Now removes following USFM markers: `\q*`, `\p*`, `\s*`

#### How to test this pull request:

Should not see markers such as `\q`, `\p`, `\s5` displayed in scripturePane

depends on https://github.com/translationCoreApps/usfm-js/pull/29


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/86)
<!-- Reviewable:end -->
