### PR TITLE
Bug fix 3862/missing lex entries

### DIFF
--- a/src/components/Verse.js
+++ b/src/components/Verse.js
@@ -14,21 +14,19 @@ const PLACE_HOLDER_TEXT = '[WARNING: This Bible version does not include text fo
 
 class Verse extends React.Component {
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.verseText && this.props.verseText !== nextProps.verseText) {
-      if ((nextProps.verseText.constructor === Array) || (nextProps.verseText.verseObjects)) {
-        const words = nextProps.actions.getWordListForVerse(nextProps.verseText);
-        words.forEach((word) => {
-          if (isWord(word)) {
-            const {strong} = word;
-            if (strong) {
-              const entryId = lexiconHelpers.lexiconEntryIdFromStrongs(strong);
-              const lexiconId = lexiconHelpers.lexiconIdFromStrongs(strong);
-              nextProps.actions.loadLexiconEntry(lexiconId, entryId);
-            }
+  componentWillMount() {
+    if ((this.props.verseText.constructor === Array) || (this.props.verseText.verseObjects)) {
+      const words = this.props.actions.getWordListForVerse(this.props.verseText);
+      words.forEach((word) => {
+        if (isWord(word)) {
+          const {strong} = word;
+          if (strong) {
+            const entryId = lexiconHelpers.lexiconEntryIdFromStrongs(strong);
+            const lexiconId = lexiconHelpers.lexiconIdFromStrongs(strong);
+            this.props.actions.loadLexiconEntry(lexiconId, entryId);
           }
-        });
-      }
+        }
+      });
     }
   }
 

--- a/src/components/Verse.js
+++ b/src/components/Verse.js
@@ -15,15 +15,25 @@ const PLACE_HOLDER_TEXT = '[WARNING: This Bible version does not include text fo
 class Verse extends React.Component {
 
   componentWillMount() {
-    if ((this.props.verseText.constructor === Array) || (this.props.verseText.verseObjects)) {
-      const words = this.props.actions.getWordListForVerse(this.props.verseText);
+    this.updateLexiconEntries(this.props)
+  }
+  
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.verseText && this.props.verseText !== nextProps.verseText) {
+      this.updateLexiconEntries(nextProps);
+    }
+  }
+
+  updateLexiconEntries(props) {
+    if ((props.verseText.constructor === Array) || (props.verseText.verseObjects)) {
+      const words = props.actions.getWordListForVerse(props.verseText);
       words.forEach((word) => {
         if (isWord(word)) {
           const {strong} = word;
           if (strong) {
             const entryId = lexiconHelpers.lexiconEntryIdFromStrongs(strong);
             const lexiconId = lexiconHelpers.lexiconIdFromStrongs(strong);
-            this.props.actions.loadLexiconEntry(lexiconId, entryId);
+            props.actions.loadLexiconEntry(lexiconId, entryId);
           }
         }
       });

--- a/src/components/Verse.js
+++ b/src/components/Verse.js
@@ -15,28 +15,30 @@ const PLACE_HOLDER_TEXT = '[WARNING: This Bible version does not include text fo
 class Verse extends React.Component {
 
   componentWillMount() {
-    this.updateLexiconEntries(this.props)
+    this.updateLexiconEntries(this.props);
   }
   
   componentWillReceiveProps(nextProps) {
-    if (nextProps.verseText && this.props.verseText !== nextProps.verseText) {
+    if (this.props.verseText !== nextProps.verseText) {
       this.updateLexiconEntries(nextProps);
     }
   }
 
   updateLexiconEntries(props) {
-    if ((props.verseText.constructor === Array) || (props.verseText.verseObjects)) {
-      const words = props.actions.getWordListForVerse(props.verseText);
-      words.forEach((word) => {
-        if (isWord(word)) {
-          const {strong} = word;
-          if (strong) {
-            const entryId = lexiconHelpers.lexiconEntryIdFromStrongs(strong);
-            const lexiconId = lexiconHelpers.lexiconIdFromStrongs(strong);
-            props.actions.loadLexiconEntry(lexiconId, entryId);
+    if (props && props.verseText) {
+      if ((props.verseText.constructor === Array) || (props.verseText.verseObjects)) {
+        const words = props.actions.getWordListForVerse(props.verseText);
+        words.forEach((word) => {
+          if (isWord(word)) {
+            const {strong} = word;
+            if (strong) {
+              const entryId = lexiconHelpers.lexiconEntryIdFromStrongs(strong);
+              const lexiconId = lexiconHelpers.lexiconIdFromStrongs(strong);
+              props.actions.loadLexiconEntry(lexiconId, entryId);
+            }
           }
-        }
-      });
+        });
+      }
     }
   }
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fixes issues that lexicon entries were not being displayed on popup initially.  This fix makes sure that they are update when component is first displayed and when content is updated.

#### Please include detailed Test instructions for your pull request:
- When you first open a project in TW, clicking on UGNT entries should show lexicon text in popup.  Click on several words to verify they have lexicon text
- then change to another group entry (left column), and again click on several words to verify they have lexicon text

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/104)
<!-- Reviewable:end -->
