### PR TITLE
Fixed Word Alignment opening with an error on the first project loaded after a new install 

### DIFF
--- a/src/components/View.js
+++ b/src/components/View.js
@@ -9,8 +9,12 @@ import AddBible from './AddBible';
 
 class View extends React.Component {
   render() {
-    let {
-      settingsReducer,
+    const {
+      settingsReducer: {
+        toolsSettings: {
+          ScripturePane
+        }
+      },
       selectSourceLanguage,
       showExpandModal,
       modalVisibility,
@@ -21,8 +25,8 @@ class View extends React.Component {
       hideExpandModal,
       hideModal
     } = this.props;
-    let currentPaneSettings = settingsReducer.toolsSettings.ScripturePane.currentPaneSettings;
-    let scripturePane = currentPaneSettings.map((paneSetting, index) => {
+    const currentPaneSettings = ScripturePane && ScripturePane.currentPaneSettings ? ScripturePane.currentPaneSettings : [];
+    const scripturePane = currentPaneSettings.map((paneSetting, index) => {
       return (
         <Pane
           {...this.props}


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fixed Word Alignment opening with an error on the first project loaded after a new install 

#### Please include detailed Test instructions for your pull request:
- **Project URL to use:** https://git.door43.org/tc01/en_tit
- Delete both translationCore folders to simulate a clean install. In other words, the `translationCore` folder in the user path and the other one in the Application Support Path (The one that contains the settings.json file). 
- Import the project from the URL above.
- Load the project with the Word Alignment tool and you should not get any errors.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/109)
<!-- Reviewable:end -->
