### PR TITLE
A single alignment box is displayed for verses that do not have any Greek text

### DIFF
--- a/__tests__/stringHelpers.test.js
+++ b/__tests__/stringHelpers.test.js
@@ -100,3 +100,35 @@ describe('punctuationWordSpacing()', () => {
     expect(stringHelpers.punctuationWordSpacing(punctuation)).toEqual('');
   });
 });
+
+describe('emptyTextInVerseObject()', () => {
+  test('Should return true if the verse object words are empty', () => {
+    const verseText = {
+      verseObjects: [
+        {
+          type: 'word',
+          text: ''
+        },
+        {
+          text: ''
+        }
+      ]
+    };
+    expect(stringHelpers.textIsEmptyInVerseObject(verseText)).toBeTruthy();
+  });
+
+  test('Should return false if the verse object words are not empty', () => {
+    const verseText = {
+      verseObjects: [
+        {
+          type: 'word',
+          text: 'hello'
+        },
+        {
+          text: ''
+        }
+      ]
+    };
+    expect(stringHelpers.textIsEmptyInVerseObject(verseText)).toBeFalsy();
+  });
+});

--- a/src/components/Verse.js
+++ b/src/components/Verse.js
@@ -68,7 +68,9 @@ class Verse extends React.Component {
   verseString(verseText) {
     verseText = removeMarker(verseText);
     verseText = verseText.replace(/\s+/g, ' ');
-    const selections= this.props.selectionsReducer.selections;
+    // if empty string then verseText = place holder warning.
+    if (verseText.length === 0) verseText = PLACE_HOLDER_TEXT;
+    const selections = this.props.selectionsReducer.selections;
     let verseTextSpans = <span>{verseText}</span>;
 
     if (selections && selections.length > 0) {
@@ -192,11 +194,11 @@ class Verse extends React.Component {
   }
 
   render() {
-    let verseSpan = <span/>;
     const { bibleId, verseText, chapter, verse, direction } = this.props;
-
+    let verseSpan = <span/>;
     let text = verseText;
-    if (!verseText) {
+
+    if (!verseText || (typeof verseText === 'object' && !verseText.verseObjects.some((word) => word.type === "word" && word.text.length > 0))) {
       text = PLACE_HOLDER_TEXT;
     }
 

--- a/src/components/Verse.js
+++ b/src/components/Verse.js
@@ -8,7 +8,7 @@ import IconButton from 'material-ui/IconButton';
 import * as lexiconHelpers from '../helpers/lexiconHelpers';
 import * as highlightHelpers from '../helpers/highlightHelpers';
 import {removeMarker} from '../helpers/UsfmHelpers';
-import {isWord, isNestedMilestone, punctuationWordSpacing} from '../helpers/stringHelpers';
+import {isWord, isNestedMilestone, punctuationWordSpacing, emptyTextInVerseObject} from '../helpers/stringHelpers';
 // components
 import WordDetails from './WordDetails';
 // constants
@@ -198,7 +198,7 @@ class Verse extends React.Component {
     let verseSpan = <span/>;
     let text = verseText;
 
-    if (!verseText || (typeof verseText === 'object' && !verseText.verseObjects.some((word) => word.type === "word" && word.text.length > 0))) {
+    if (!verseText || (verseText.verseObject && emptyTextInVerseObject(verseText))) {
       text = PLACE_HOLDER_TEXT;
     }
 

--- a/src/components/Verse.js
+++ b/src/components/Verse.js
@@ -8,7 +8,7 @@ import IconButton from 'material-ui/IconButton';
 import * as lexiconHelpers from '../helpers/lexiconHelpers';
 import * as highlightHelpers from '../helpers/highlightHelpers';
 import {removeMarker} from '../helpers/UsfmHelpers';
-import {isWord, isNestedMilestone, punctuationWordSpacing, emptyTextInVerseObject} from '../helpers/stringHelpers';
+import {isWord, isNestedMilestone, punctuationWordSpacing, textIsEmptyInVerseObject} from '../helpers/stringHelpers';
 // components
 import WordDetails from './WordDetails';
 // constants
@@ -198,7 +198,7 @@ class Verse extends React.Component {
     let verseSpan = <span/>;
     let text = verseText;
 
-    if (!verseText || (verseText.verseObject && emptyTextInVerseObject(verseText))) {
+    if (!verseText || (verseText.verseObject && textIsEmptyInVerseObject(verseText))) {
       text = PLACE_HOLDER_TEXT;
     }
 

--- a/src/helpers/stringHelpers.js
+++ b/src/helpers/stringHelpers.js
@@ -27,7 +27,7 @@ export function punctuationWordSpacing(word) {
   return ((lastChar === '"') || (lastChar === "'") || (lastChar === "-")) ? '' : ' ';
 }
 
-export function emptyTextInVerseObject(verseText) {
+export function textIsEmptyInVerseObject(verseText) {
   const emptyVerse = !verseText.verseObjects.some((word) => word.type === "word" && word.text.length > 0);
 
   return typeof verseText === 'object' && emptyVerse;

--- a/src/helpers/stringHelpers.js
+++ b/src/helpers/stringHelpers.js
@@ -26,3 +26,9 @@ export function punctuationWordSpacing(word) {
   const lastChar = word.text.substr(word.text.length - 1);
   return ((lastChar === '"') || (lastChar === "'") || (lastChar === "-")) ? '' : ' ';
 }
+
+export function emptyTextInVerseObject(verseText) {
+  const emptyVerse = !verseText.verseObjects.some((word) => word.type === "word" && word.text.length > 0);
+
+  return typeof verseText === 'object' && emptyVerse;
+}


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- A single alignment box is displayed for verses that do not have any Greek text

#### Please include detailed Test instructions for your pull request:
- Open a project with `wordAlignment tool` that has an empty verse. 
- Go to that empty verse and a warning should display (`[WARNING: This Bible version does not include text for this reference.]`)
- Empty verses in the scripture pane should also render the same message.
- **Dependencies:**
   - https://github.com/translationCoreApps/wordAlignment/pull/34

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/scripturepane/117)
<!-- Reviewable:end -->
